### PR TITLE
Datanode UI: Proxy config for local runtime via maven

### DIFF
--- a/datanode-ui/.env.development
+++ b/datanode-ui/.env.development
@@ -1,1 +1,0 @@
-PROXY_HOST="https://testnodestandalone.arachnenetwork.com/"

--- a/datanode-ui/README.md
+++ b/datanode-ui/README.md
@@ -1,3 +1,14 @@
+# Running Locally
+
+The application can be started using `mvn site` command line. In this mode, it is configured to 
+use backend running at https://localhost:8880 which is default port for running backend locally. 
+
+If you want to connect to remote backend, set environment variable PROXY_HOST with the url of the target host.
+This can be done, for example, by creating ".env" file in the same directory where this README file resides, 
+with the following contents:
+
+    PROXY_HOST="https://<target-host>"
+
 # Getting Started with Create React App
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).

--- a/datanode-ui/pom.xml
+++ b/datanode-ui/pom.xml
@@ -69,6 +69,9 @@
                         </goals>
                         <configuration>
                             <arguments>run start</arguments>
+                            <environmentVariables>
+                                <PROXY_HOST>https://localhost:8880</PROXY_HOST>
+                            </environmentVariables>
                         </configuration>
                     </execution>
 <!--                        <execution>-->

--- a/datanode-ui/src/setupProxy.js
+++ b/datanode-ui/src/setupProxy.js
@@ -23,6 +23,9 @@ module.exports = function (app) {
     createProxyMiddleware({
       target: process.env.PROXY_HOST,
       changeOrigin: true,
+      // Disable SSL when the target is https. Required for running against local backend, otherwise, proxying fails with the an error like:
+      // Error occurred while proxying request localhost:3000/api/v1/auth/login to https://localhost:8880/ [DEPTH_ZERO_SELF_SIGNED_CERT]
+      secure: false
     })
   );
 };


### PR DESCRIPTION
Default to local env when running from maven, remove specific host from configuration, add readme section on running locally